### PR TITLE
Remove gir-files from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.3.0"
 description = "Rust bindings for the GtkSourceView 3 library"
 repository = "https://github.com/gtk-rs/sourceview"
 build = "build.rs"
+exclude = [
+    "gir-files/*",
+]
 
 [lib]
 name = "sourceview"


### PR DESCRIPTION
Part of https://github.com/gtk-rs/glib/issues/289

cc @GuillaumeGomez
