### PR TITLE
Remove the unused dependency on fragile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,6 @@ features = ["dox", "embed-lgpl-docs"]
 libc = "0.2"
 bitflags = "1.0"
 
-[dependencies.fragile]
-version = "0.3"
-
 [dependencies.gtk-source-sys]
 path = "./sourceview-sys"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@ extern crate libc;
 #[macro_use]
 extern crate bitflags;
 
-extern crate fragile;
-
 pub use auto::*;
 pub use completion::*;
 pub use completion_info::*;


### PR DESCRIPTION
All uses of `fragile` were removed in #116.

Closes #121.